### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,8 @@ If you encounter permissions issues (403 Forbidden), check:
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/kopfrechner-gitlab-mr-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/kopfrechner-gitlab-mr-mcp).